### PR TITLE
[nightshift] dead-code: unexport unused functions

### DIFF
--- a/src/features/runs/engine.ts
+++ b/src/features/runs/engine.ts
@@ -163,7 +163,7 @@ export async function getLastRunOutput(): Promise<LastRunRecord | null> {
   return getLastRun()
 }
 
-export async function clearLastRunOutput(): Promise<void> {
+async function clearLastRunOutput(): Promise<void> {
   await clearLastRun()
 }
 

--- a/src/features/runs/prompting.ts
+++ b/src/features/runs/prompting.ts
@@ -128,7 +128,7 @@ export function postProcessOutput(
   return output
 }
 
-export function stripMarkdownAndFiller(value: string): string {
+function stripMarkdownAndFiller(value: string): string {
   let output = String(value || "")
   output = output.replace(/^```(?:json)?\s*|\s*```$/gim, "").trim()
   output = output.replace(/^\s*[*_#>\-]+/gm, "").trim()


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** dead-code
**Category:** pr
**Changes:**
- Unexport `clearLastRunOutput` in `engine.ts` — function is exported but never called outside its own module (only wraps `clearLastRun`)
- Unexport `stripMarkdownAndFiller` in `prompting.ts` — function is exported but only used internally by `postProcessOutput` in the same file

No behavioral changes. Codebase is very clean — only these two unused exports found.

Merge if useful, close if not.